### PR TITLE
Update np.NaN to np.nan

### DIFF
--- a/ztfquery/marshal.py
+++ b/ztfquery/marshal.py
@@ -66,7 +66,7 @@ def convert_lc_tofritz(marshal_lc, name):
 
     from astropy import time
     data = marshal_lc[["filter","mag","emag","limmag"]].rename({"emag":"magerr", "limmag":"limiting_mag"},
-                                                                   axis=1).replace(to_replace=99.0, value=np.NaN)
+                                                                   axis=1).replace(to_replace=99.0, value=np.nan)
     flag_gri = data["filter"].isin(["g","r","i"])
     data.loc[flag_gri,"filter"] = "ztf"+data.loc[flag_gri,"filter"].astype('str')
     data["mjd"] = time.Time(marshal_lc["jdobs"].astype("float"), format="jd").mjd
@@ -75,7 +75,7 @@ def convert_lc_tofritz(marshal_lc, name):
     data["instrument_name"] = marshal_lc["instrument"].str.split("+", expand=True)[1]
     for k in ['ra', 'dec','ra_unc', 'dec_unc', 'id', 'groups', 'altdata', 
               'instrument_id',"origin"]:
-        data[k] = np.NaN
+        data[k] = np.nan
 
     return data[fritz_keys]
 

--- a/ztfquery/skyvision.py
+++ b/ztfquery/skyvision.py
@@ -1312,7 +1312,7 @@ class CompletedLog(ZTFLog):
         )
 
     def get_program_data(
-        self, what="size", key=None, programs=None, filterprop={}, fill_value=np.NaN
+        self, what="size", key=None, programs=None, filterprop={}, fill_value=np.nan
     ):
         """
 
@@ -1360,7 +1360,7 @@ class CompletedLog(ZTFLog):
                 return groupbys
 
         if fill_value is None:
-            fill_value = np.NaN
+            fill_value = np.nan
 
         # get list
         baseindex = np.unique(groupbys.index.get_level_values(0))


### PR DESCRIPTION
As of the recently-released numpy v2 (https://numpy.org/doc/stable/release/2.0.0-notes.html), `np.NaN` has been finally removed. This PR updates the uses of `np.NaN` to the non-deprecated `np.nan`, which does the same thing.