### PR TITLE
Remove forced paddedfield for bias

### DIFF
--- a/ztfquery/buildurl.py
+++ b/ztfquery/buildurl.py
@@ -361,9 +361,9 @@ def raw_path(
 
     """
     source = _source_to_location_(source)
-    if imgtypecode == "b":
-        paddedfield = "000000"
-
+    #if imgtypecode == "b":
+    #    paddedfield = "000000"
+    
     filefracday = "".join([year + month + day + fracday])
     file_ = (
         "raw/"


### PR DESCRIPTION
raw_path did not provide the proper path to some biases that actually have a recorded field in their filename.  Remove the forced paddedfield for bias files.
@MickaelRigault 